### PR TITLE
Add toggle: focus tab on key up

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { Platform, Plugin, WorkspaceLeaf } from "obsidian";
 import { GeneralModal } from "./modal";
 import CTPSettingTab from "./settingsTab";
-import { DEFAULT_SETTINGS, Settings } from "./types";
+import { DEFAULT_SETTINGS, NEW_USER_SETTINGS, Settings } from "./types";
 
 export default class CycleThroughPanes extends Plugin {
     settings: Settings;
@@ -297,10 +297,13 @@ export default class CycleThroughPanes extends Plugin {
     }
 
     async loadSettings() {
+        // returns null if .obsidian/plugins/cycle-through-panes/data.json does not exist
+        const userSettings = await this.loadData()
+
         this.settings = Object.assign(
             {},
             DEFAULT_SETTINGS,
-            await this.loadData()
+            userSettings ? userSettings : NEW_USER_SETTINGS
         );
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,6 @@ export default class CycleThroughPanes extends Plugin {
     settings: Settings;
     ctrlPressedTimestamp = 0;
     ctrlKeyCode: string | undefined;
-    // TODO move to settings
-    focusLeafOnKeyUp = true // set to false to restore original behavior
     queuedFocusLeaf: WorkspaceLeaf
     leafIndex = 0;
     modal: GeneralModal | undefined;
@@ -230,7 +228,7 @@ export default class CycleThroughPanes extends Plugin {
     }
 
     queueFocusLeaf(leaf: WorkspaceLeaf) {
-        if (this.focusLeafOnKeyUp) {
+        if (this.settings.focusLeafOnKeyUp) {
             this.queuedFocusLeaf = leaf
         } else {
             this.focusLeaf(leaf)

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ export default class CycleThroughPanes extends Plugin {
     settings: Settings;
     ctrlPressedTimestamp = 0;
     ctrlKeyCode: string | undefined;
-    queuedFocusLeaf: WorkspaceLeaf
+    queuedFocusLeaf: WorkspaceLeaf;
     leafIndex = 0;
     modal: GeneralModal | undefined;
     leaves: WorkspaceLeaf[];
@@ -229,9 +229,9 @@ export default class CycleThroughPanes extends Plugin {
 
     queueFocusLeaf(leaf: WorkspaceLeaf) {
         if (this.settings.focusLeafOnKeyUp) {
-            this.queuedFocusLeaf = leaf
+            this.queuedFocusLeaf = leaf;
         } else {
-            this.focusLeaf(leaf)
+            this.focusLeaf(leaf);
         }
     }
 
@@ -271,7 +271,7 @@ export default class CycleThroughPanes extends Plugin {
             this.ctrlKeyCode = e.code;
 
             // clean slate -- prevent ctrl keystroke from accidentally switching to another tab
-            this.queuedFocusLeaf = undefined
+            this.queuedFocusLeaf = undefined;
         }
     }
 
@@ -283,7 +283,7 @@ export default class CycleThroughPanes extends Plugin {
             this.modal?.close();
 
             if (this.queuedFocusLeaf) {
-                this.focusLeaf(this.queuedFocusLeaf)
+                this.focusLeaf(this.queuedFocusLeaf);
             }
 
             this.modal = undefined;
@@ -298,7 +298,7 @@ export default class CycleThroughPanes extends Plugin {
 
     async loadSettings() {
         // returns null if .obsidian/plugins/cycle-through-panes/data.json does not exist
-        const userSettings = await this.loadData()
+        const userSettings = await this.loadData();
 
         this.settings = Object.assign(
             {},

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,9 @@ export default class CycleThroughPanes extends Plugin {
     settings: Settings;
     ctrlPressedTimestamp = 0;
     ctrlKeyCode: string | undefined;
+    // TODO move to settings
+    focusLeafOnKeyUp = true // set to false to restore original behavior
+    queuedFocusLeaf: WorkspaceLeaf
     leafIndex = 0;
     modal: GeneralModal | undefined;
     leaves: WorkspaceLeaf[];
@@ -69,9 +72,9 @@ export default class CycleThroughPanes extends Plugin {
                         const index = leaves.indexOf(active);
 
                         if (index === leaves.length - 1) {
-                            this.focusLeaf(leaves[0]);
+                            this.queueFocusLeaf(leaves[0]);
                         } else {
-                            this.focusLeaf(leaves[index + 1]);
+                            this.queueFocusLeaf(leaves[index + 1]);
                         }
                     }
                     return true;
@@ -94,9 +97,9 @@ export default class CycleThroughPanes extends Plugin {
 
                         if (index !== undefined) {
                             if (index === 0) {
-                                this.focusLeaf(leaves[leaves.length - 1]);
+                                this.queueFocusLeaf(leaves[leaves.length - 1]);
                             } else {
-                                this.focusLeaf(leaves[index - 1]);
+                                this.queueFocusLeaf(leaves[index - 1]);
                             }
                         }
                     }
@@ -159,7 +162,7 @@ export default class CycleThroughPanes extends Plugin {
                         }
                     }
                 });
-                this.focusLeaf(leaf);
+                this.queueFocusLeaf(leaf);
             },
         });
 
@@ -176,7 +179,7 @@ export default class CycleThroughPanes extends Plugin {
                         }
                     }
                 });
-                this.focusLeaf(leaf);
+                this.queueFocusLeaf(leaf);
             },
         });
 
@@ -197,7 +200,7 @@ export default class CycleThroughPanes extends Plugin {
                 const leaf = leaves[this.leafIndex];
 
                 if (leaf) {
-                    this.focusLeaf(leaf);
+                    this.queueFocusLeaf(leaf);
                 }
             },
         });
@@ -217,13 +220,21 @@ export default class CycleThroughPanes extends Plugin {
                 const leaf = leaves[this.leafIndex];
 
                 if (leaf) {
-                    this.focusLeaf(leaf);
+                    this.queueFocusLeaf(leaf);
                 }
             },
         });
 
         window.addEventListener("keydown", this.keyDownFunc);
         window.addEventListener("keyup", this.keyUpFunc);
+    }
+
+    queueFocusLeaf(leaf: WorkspaceLeaf) {
+        if (this.focusLeafOnKeyUp) {
+            this.queuedFocusLeaf = leaf
+        } else {
+            this.focusLeaf(leaf)
+        }
     }
 
     focusLeaf(leaf: WorkspaceLeaf) {
@@ -269,6 +280,10 @@ export default class CycleThroughPanes extends Plugin {
             this.leaves = null;
 
             this.modal?.close();
+
+            if (this.queueFocusLeaf) {
+                this.focusLeaf(this.queuedFocusLeaf)
+            }
 
             this.modal = undefined;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -271,6 +271,9 @@ export default class CycleThroughPanes extends Plugin {
         if (e.key == "Control") {
             this.ctrlPressedTimestamp = e.timeStamp;
             this.ctrlKeyCode = e.code;
+
+            // clean slate -- prevent ctrl keystroke from accidentally switching to another tab
+            this.queuedFocusLeaf = undefined
         }
     }
 
@@ -281,7 +284,7 @@ export default class CycleThroughPanes extends Plugin {
 
             this.modal?.close();
 
-            if (this.queueFocusLeaf) {
+            if (this.queuedFocusLeaf) {
                 this.focusLeaf(this.queuedFocusLeaf)
             }
 

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -55,6 +55,6 @@ export class GeneralModal extends SuggestModal<string> {
     onChooseSuggestion(item: string, evt: MouseEvent | KeyboardEvent) {}
 
     focusTab(): void {
-        this.plugin.focusLeaf(this.leaves[this.chooser.selectedItem]);
+        this.plugin.queueFocusLeaf(this.leaves[this.chooser.selectedItem]);
     }
 }

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -59,6 +59,17 @@ export default class CTPSettingTab extends PluginSettingTab {
                 });
             });
 
+        new Setting(containerEl)
+            .setName("Focus tab on release")
+            .setDesc("If enabled, defer switching tabs until the ctrl key is released, similar to VS Code and Firefox")
+            .addToggle((cb) => {
+                cb.setValue(this.settings.focusLeafOnKeyUp);
+                cb.onChange(async (value) => {
+                    this.settings.focusLeafOnKeyUp = value;
+                    await this.plugin.saveSettings();
+                });
+            });
+
         new Setting(containerEl).setName("Skip pinned tabs").addToggle((cb) => {
             cb.setValue(this.settings.skipPinned);
             cb.onChange(async (value) => {

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -61,7 +61,9 @@ export default class CTPSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName("Focus tab on release")
-            .setDesc("If enabled, defer switching tabs until the ctrl key is released, similar to VS Code and Firefox")
+            .setDesc(
+                "If enabled, defer switching tabs until the ctrl key is released, similar to VS Code and Firefox"
+            )
             .addToggle((cb) => {
                 cb.setValue(this.settings.focusLeafOnKeyUp);
                 cb.onChange(async (value) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,12 @@ export const DEFAULT_SETTINGS: Settings = {
     showModal: true,
     skipPinned: false,
     stayInSplit: true,
-    focusLeafOnKeyUp: false,
+    focusLeafOnKeyUp: false, // opt-in for existing users
 };
+
+export const NEW_USER_SETTINGS: Partial<Settings> = {
+    focusLeafOnKeyUp: true, // default for new users
+}
 
 declare module "obsidian" {
     interface App {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface Settings {
     showModal: boolean;
     skipPinned: boolean;
     stayInSplit: boolean;
+    focusLeafOnKeyUp: boolean;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -10,6 +11,7 @@ export const DEFAULT_SETTINGS: Settings = {
     showModal: true,
     skipPinned: false,
     stayInSplit: true,
+    focusLeafOnKeyUp: false,
 };
 
 declare module "obsidian" {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export const DEFAULT_SETTINGS: Settings = {
 
 export const NEW_USER_SETTINGS: Partial<Settings> = {
     focusLeafOnKeyUp: true, // default for new users
-}
+};
 
 declare module "obsidian" {
     interface App {


### PR DESCRIPTION
Here's a proof of concept for fixing issue #21. I didn't test yet how this affects other features of the plugin, because I'm not familiar with them. @phibr0 can you please have a look and let me know what's needed to merge this into the next version of the plugin?