### PR TITLE
Add per-workspace tab history maintenance using workspace names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ main.js
 
 # obsidian
 data.json
+
+# .DS_Store
+.DS_Store

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "cycle-through-panes",
   "name": "Tab Switcher",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "minAppVersion": "0.15.0",
   "description": "Switch your tabs with Ctrl + Tab in recently used order like in a browser.",
   "author": "Vinzent & phibr0",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "cycle-through-panes",
   "name": "Tab Switcher",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "minAppVersion": "0.15.0",
   "description": "Switch your tabs with Ctrl + Tab in recently used order like in a browser.",
   "author": "Vinzent & phibr0",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
     "@types/node": "^14.14.2",
-    "obsidian": "^1.1.1",
-    "standard-version": "^9.5.0",
+    "obsidian": "^1.7.2",
     "rollup": "^2.32.1",
+    "standard-version": "^9.5.0",
     "tslib": "^2.0.3",
     "typescript": "^4.0.3"
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,24 +1,31 @@
 export interface Settings {
-    viewTypes: string[];
-    showModal: boolean;
     skipPinned: boolean;
-    stayInSplit: boolean;
-    focusLeafOnKeyUp: boolean;
     useViewTypes: boolean;
+    viewTypes: string[];
+    focusLeafOnKeyUp: boolean;
+    showModal: boolean;
+    stayInSplit: boolean;
+    tabHistoryPerWorkspace: { [workspaceId: string]: string[] };
 }
 
 export const DEFAULT_SETTINGS: Settings = {
-    viewTypes: ["markdown", "canvas", "pdf"],
-    showModal: true,
-    skipPinned: false,
-    stayInSplit: true,
-    focusLeafOnKeyUp: false, // opt-in for existing users
-    useViewTypes: true,
+    skipPinned: true,
+    useViewTypes: false,
+    viewTypes: [],
+    focusLeafOnKeyUp: false,
+    showModal: false,
+    stayInSplit: false,
+    tabHistoryPerWorkspace: {},
 };
 
-export const NEW_USER_SETTINGS: Partial<Settings> = {
-    focusLeafOnKeyUp: true, // default for new users
+export const NEW_USER_SETTINGS: Settings = {
+    skipPinned: false,
     useViewTypes: false,
+    viewTypes: [],
+    focusLeafOnKeyUp: true,
+    showModal: false,
+    stayInSplit: false,
+    tabHistoryPerWorkspace: {},
 };
 
 declare module "obsidian" {


### PR DESCRIPTION
- Utilize workspace names via  to uniquely identify workspaces.
- Store and restore tab history for each workspace.
- Maintain tab history when switching between workspaces, similar to VS Code behavior.
- Ensure compatibility by handling cases where the Workspaces plugin is disabled.

To be honest, I heavily used GPT o1-preview to make this code. I tested it though with logs and everything seems to be working as it should. The history is maintained after switching workspaces.